### PR TITLE
Initial implementation for `download --skip-patches`

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -434,7 +434,7 @@ func DownloadGameFiles(
 						continue
 					}
 					if strings.Contains(*file.ManualURL, "en1patch") {
-						log.Info().Msgf("Skipping patch in game %s, platform %s, file name %s", game.Title, platformFiles.subDir, *file.ManualURL)
+						fmt.Fprintf(progressWriter, "Skipping patch in game %s, platform %s, file name %s\n", game.Title, platformFiles.subDir, *file.ManualURL)
 						continue
 					}
 					url := fmt.Sprintf("https://embed.gog.com%s", *file.ManualURL)

--- a/client/download.go
+++ b/client/download.go
@@ -79,7 +79,7 @@ func DownloadGameFiles(
 	ctx context.Context, // Add context parameter
 	accessToken string, game Game, downloadPath string,
 	gameLanguage string, platformName string, extrasFlag bool, dlcFlag bool, resumeFlag bool,
-	flattenFlag bool, numThreads int,
+	flattenFlag bool, skipPatchesFlag bool, numThreads int,
 	progressWriter io.Writer, // Add writer parameter
 ) error {
 	client := &http.Client{} // Standard client for most requests
@@ -431,6 +431,10 @@ func DownloadGameFiles(
 				for _, file := range platformFiles.files {
 					if file.ManualURL == nil || *file.ManualURL == "" {
 						log.Warn().Msgf("Skipping file with nil or empty ManualURL in game %s, platform %s", game.Title, platformFiles.subDir)
+						continue
+					}
+					if strings.Contains(*file.ManualURL, "en1patch") {
+						log.Info().Msgf("Skipping patch in game %s, platform %s, file name %s", game.Title, platformFiles.subDir, *file.ManualURL)
 						continue
 					}
 					url := fmt.Sprintf("https://embed.gog.com%s", *file.ManualURL)

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,6 +130,7 @@ The `download` command supports the following additional options:
 - `--resume`: Resume interrupted downloads (default is true)
 - `--threads`: Number of worker threads to use for downloading (default is 5)
 - `--flatten`: Flatten the directory structure of the downloaded files (default is true)
+- `--skip-patches`: Skip patches when downloading (default is false)
 
 For example, to download all files (English language) of a game with the ID `<game_id>` to the directory
 `<download_dir>` with the specified options:

--- a/gui/download.go
+++ b/gui/download.go
@@ -133,8 +133,10 @@ func DownloadUI(win fyne.Window) fyne.CanvasObject {
 	resumeCheck.SetChecked(true)
 	flattenCheck := widget.NewCheck("Flatten Structure", nil)
 	flattenCheck.SetChecked(true)
+	skipPatchesCheck := widget.NewCheck("Skip Patches", nil)
+	skipPatchesCheck.SetChecked(false)
 
-	row3 := container.NewHBox(extrasCheck, dlcCheck, resumeCheck, flattenCheck)
+	row3 := container.NewHBox(extrasCheck, dlcCheck, resumeCheck, flattenCheck, skipPatchesCheck)
 
 	downloadBtn := widget.NewButton("Download Game", nil)
 	cancelBtn := widget.NewButton("Cancel Download", nil)
@@ -189,6 +191,7 @@ func DownloadUI(win fyne.Window) fyne.CanvasObject {
 		dlcFlag := dlcCheck.Checked
 		resumeFlag := resumeCheck.Checked
 		flattenFlag := flattenCheck.Checked
+		skipPatchesFlag := skipPatchesCheck.Checked
 
 		fyne.Do(func() {
 			logOutput.SetText("")
@@ -213,7 +216,7 @@ func DownloadUI(win fyne.Window) fyne.CanvasObject {
 				})
 			}()
 
-			executeDownloadUI(downloadCtx, gameID, downloadDir, lang, platform, extrasFlag, dlcFlag, resumeFlag, flattenFlag, numThreads, logOutput, progressWriter)
+			executeDownloadUI(downloadCtx, gameID, downloadDir, lang, platform, extrasFlag, dlcFlag, resumeFlag, flattenFlag, skipPatchesFlag, numThreads, logOutput, progressWriter)
 		}()
 	}
 
@@ -231,7 +234,7 @@ func DownloadUI(win fyne.Window) fyne.CanvasObject {
 }
 
 func executeDownloadUI(ctx context.Context, gameID int, downloadPath, language, platformName string,
-	extrasFlag, dlcFlag, resumeFlag, flattenFlag bool, numThreads int, logOutput *widget.Entry,
+	extrasFlag, dlcFlag, resumeFlag, flattenFlag, skipPatchesFlag bool, numThreads int, logOutput *widget.Entry,
 	progressWriter io.Writer,
 ) {
 	appendLog(logOutput, fmt.Sprintf("Starting download for game ID %d...", gameID))
@@ -290,7 +293,7 @@ func executeDownloadUI(ctx context.Context, gameID int, downloadPath, language, 
 	err = client.DownloadGameFiles(
 		ctx,
 		token.AccessToken, parsedGameData, downloadPath, language, platformName,
-		extrasFlag, dlcFlag, resumeFlag, flattenFlag, numThreads,
+		extrasFlag, dlcFlag, resumeFlag, flattenFlag, skipPatchesFlag, numThreads,
 		progressWriter,
 	)
 


### PR DESCRIPTION
Patches can be large and some want to skip them while downloading.  This pull request can close https://github.com/habedi/gogg/issues/34