### PR TITLE
Add macOS binary names to login client

### DIFF
--- a/client/login.go
+++ b/client/login.go
@@ -125,7 +125,7 @@ func (c *GogClient) Login(loginURL string, username string, password string, hea
 func createChromeContext(headless bool) (context.Context, context.CancelFunc, error) {
 	var execPath string
 	// Search for browsers in order of preference
-	browserExecutables := []string{"google-chrome", "chromium", "chrome", "msedge"}
+	browserExecutables := []string{"google-chrome", "Google Chrome", "chromium", "Chromium", "chrome", "msedge", "Microsoft Edge"}
 	for _, browser := range browserExecutables {
 		if p, err := exec.LookPath(browser); err == nil {
 			execPath = p


### PR DESCRIPTION
macOS uses different binary names for Chrome, Chromium, and Edge than other platforms do (I know it looks weird, but they really do have spaces in them).  This adds them to the list so that they can be found, as the existing code can't log in because it can't find the browser.

This does still require adding the browser binary location to the path, though, even if it's only for the login flow.  So in order to log in after making my modifications here and rebuilding the binary, I did this:

`PATH=$PATH:/Applications/Google\ Chrome.app/Contents/MacOS/ ./gogg login`