### PR TITLE
Update .editorconfig for spec compliance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,18 @@ root = true
 
 # Global settings (applicable to all files unless overridden)
 [*]
-charset = utf-8 # Default character encoding
-end_of_line = lf # Use LF for line endings (Unix-style)
-indent_style = space # Use spaces for indentation
-indent_size = 4 # Default indentation size
-insert_final_newline = true # Make sure files end with a newline
-trim_trailing_whitespace = true # Remove trailing whitespace
+# Default character encoding
+charset = utf-8
+# Use LF for line endings (Unix-style)
+end_of_line = lf
+# Use spaces for indentation
+indent_style = space
+# Default indentation size
+indent_size = 4
+# Make sure files end with a newline
+insert_final_newline = true
+# Remove trailing whitespace
+trim_trailing_whitespace = true
 
 # Go files
 [*.go]


### PR DESCRIPTION
I was seeing errors in my editor (Neovim) when I was making my changes that I submitted yesterday, so I looked into them today.

It seems that the EditorConfig spec [changed as of version 0.15.0](https://spec.editorconfig.org/#id8) to non longer allow inline comments.  This change moves the comments that were inline to the line before.  Doing that resolves the errors I was seeing in my editor.